### PR TITLE
[codex] Migrate AI calls to GPT-5.5

### DIFF
--- a/app/api/notes/diffs/summarize/route.tsx
+++ b/app/api/notes/diffs/summarize/route.tsx
@@ -1,9 +1,8 @@
-import { TextBlock } from '@anthropic-ai/sdk/resources/messages.mjs'
 import { NextRequest } from 'next/server'
 
 import { getDiffSummarizationPrompt } from '@/prompts/notes/note-summary-user'
 import { RouteMessageMap } from '@/types/upstash'
-import { getAnthropic } from '@/utils/ai'
+import { generateAiText } from '@/utils/ai'
 import { getRedis } from '@/utils/redis'
 import { verifyUpstashSignature } from '@/utils/upstash'
 
@@ -12,18 +11,12 @@ export async function POST(req: NextRequest) {
 
   const body: RouteMessageMap['/api/notes/diffs/summarize'] =
     await verifyUpstashSignature(req)
-  const response = await getAnthropic().messages.create({
-    max_tokens: 1000,
-    model: 'claude-sonnet-4-20250514',
-
-    messages: [
-      { role: 'user', content: getDiffSummarizationPrompt(body.diff.diff) },
-    ],
+  const responseContent = await generateAiText({
+    prompt: getDiffSummarizationPrompt(body.diff.diff),
   })
-  if (!response.content || !response.content[0]) {
+  if (!responseContent) {
     return new Response('No content found in response', { status: 500 })
   }
-  const responseContent = (response.content[0] as TextBlock).text
   const redis = getRedis()
   await redis.hset(body.keys.notesKey, {
     [body.diff.filename]: responseContent.trim(),

--- a/app/api/notes/summarize/route.tsx
+++ b/app/api/notes/summarize/route.tsx
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getNoteSummarizationPrompt } from '@/prompts/notes/note-summary-user'
 import { RouteMessageMap } from '@/types/upstash'
-import { getOpenAI, O3_CONFIG } from '@/utils/ai'
+import { generateAiText } from '@/utils/ai'
 import { getRedis } from '@/utils/redis'
 import { verifyUpstashSignature } from '@/utils/upstash'
 export const maxDuration = 300
@@ -11,31 +11,13 @@ export async function POST(req: NextRequest) {
   console.log('POST /api/notes/summarize')
   const body: RouteMessageMap['/api/notes/summarize'] =
     await verifyUpstashSignature(req)
-  const response = await getOpenAI().chat.completions.create({
-    ...O3_CONFIG,
-    messages: [
-      {
-        role: 'user',
-        content: getNoteSummarizationPrompt(body.note.filename, body.note.body),
-      },
-    ],
+  const responseContent = await generateAiText({
+    prompt: getNoteSummarizationPrompt(body.note.filename, body.note.body),
   })
-  //   const response = await anthropic.messages.create({
-  //     max_tokens: 1000,
-  //     model: 'claude-3-5-sonnet-20240620',
 
-  //     messages: [
-  //       {
-  //         role: 'user',
-  //         content: getNoteSummarizationPrompt(body.note.filename, body.note.body),
-  //       },
-  //     ],
-  //   })
-  if (!response.choices[0]?.message?.content) {
+  if (!responseContent) {
     return new Response('No content found in response', { status: 500 })
   }
-  //   const responseContent = (response.content[0] as TextBlock).text
-  const responseContent = response.choices[0].message.content
   const redis = getRedis()
   await redis.hset(body.keys.notesKey, {
     [body.note.filename]: responseContent.trim(),

--- a/app/api/summarize/daily/route.tsx
+++ b/app/api/summarize/daily/route.tsx
@@ -9,7 +9,12 @@ import {
 } from '@/prompts/summarize/daily-summary-user'
 import { RouteMessageMap } from '@/types/upstash'
 import { UrlBodies } from '@/types/urls'
-import { getOpenAI, O3_CONFIG, validateMarkdownContent } from '@/utils/ai'
+import {
+  generateAiObject,
+  generateAiText,
+  hasAiCredentials,
+  validateMarkdownContent,
+} from '@/utils/ai'
 import { formatCalendarEvents, getDaysEvents } from '@/utils/calendar'
 import { createOrUpdateFile, getRecentFiles } from '@/utils/github'
 import { getRedis } from '@/utils/redis'
@@ -59,25 +64,18 @@ export async function POST(req: NextRequest) {
     urlsArray ? `\n${formatInputs(urlsArray)}` : ''
   }`.trim()
 
-  const response = await getOpenAI().chat.completions.create({
-    ...O3_CONFIG,
-    messages: [
-      { role: 'system', content: DAILY_SUMMARY_SYSTEM_PROMPT },
-      {
-        role: 'user',
-        content: getDailySummaryUserPrompt({
-          date: dayjs(body.date).format('MMMM D, YYYY'),
-          notes: notesString,
-        }),
-      },
-    ],
+  const responseString = await generateAiText({
+    prompt: getDailySummaryUserPrompt({
+      date: dayjs(body.date).format('MMMM D, YYYY'),
+      notes: notesString,
+    }),
+    system: DAILY_SUMMARY_SYSTEM_PROMPT,
   })
 
-  if (!response.choices[0]?.message?.content) {
+  if (!responseString) {
     return new Response('No content found in response', { status: 500 })
   }
-  const responseString = response.choices[0].message.content
-  
+
   if (!validateMarkdownContent(responseString)) {
     console.error('Invalid markdown content received from AI')
     return new Response('Invalid content in AI response', { status: 500 })
@@ -140,7 +138,7 @@ export async function GET(req: NextRequest) {
   ) {
     return new Response('Unauthorized', { status: 401 })
   }
-  if (!process.env.YOUR_NAME || !process.env.OPENAI_API_KEY) {
+  if (!process.env.YOUR_NAME || !hasAiCredentials()) {
     // Treating this as if user does not want daily summaries.
     return new Response('Missing environment variables', { status: 200 })
   }
@@ -164,29 +162,14 @@ export async function GET(req: NextRequest) {
       urls.push(url)
     })
   })
-  const openaiResponse = await getOpenAI().chat.completions.create({
-    model: 'gpt-4o-2024-08-06',
-    messages: [
-      {
-        role: 'system',
-        content:
-          'You will be given an array of URLs. Your job is to return the urls that represent valuable content, not the ones that are generic (like google.com, yahoo.com, nytimes.com, cnn.com, etc.), redirects, generic, shortened, and otherwise not useful. Return urls in this JSON format: {usefulUrls: string[]}',
-      },
-      {
-        role: 'user',
-        content: `URLs: ${JSON.stringify(urls)}}\nUseful URLs:`,
-      },
-    ],
-    response_format: { type: 'json_object' },
-  })
-  if (!openaiResponse.choices[0].message.content) {
-    return new Response('No content found in response', { status: 500 })
-  }
   let parsed
   try {
-    parsed = UsefulUrls.parse(
-      JSON.parse(openaiResponse.choices[0].message.content),
-    )
+    parsed = await generateAiObject({
+      prompt: `URLs: ${JSON.stringify(urls)}\nUseful URLs:`,
+      schema: UsefulUrls,
+      system:
+        'You will be given an array of URLs. Your job is to return the urls that represent valuable content, not the ones that are generic (like google.com, yahoo.com, nytimes.com, cnn.com, etc.), redirects, generic, shortened, and otherwise not useful.',
+    })
   } catch (error) {
     console.error('Error parsing response:', error)
     return new Response('Error parsing response', { status: 500 })

--- a/app/api/summarize/weekly/route.tsx
+++ b/app/api/summarize/weekly/route.tsx
@@ -9,7 +9,11 @@ import {
 } from '@/prompts/summarize/weekly-summary-user'
 import { RecentFile } from '@/types/files'
 import { RouteMessageMap } from '@/types/upstash'
-import { getOpenAI, O3_CONFIG, validateMarkdownContent } from '@/utils/ai'
+import {
+  generateAiText,
+  hasAiCredentials,
+  validateMarkdownContent,
+} from '@/utils/ai'
 import { createOrUpdateFile, getDailySummaries } from '@/utils/github'
 import { publishToUpstash, verifyUpstashSignature } from '@/utils/upstash'
 export const dynamic = 'force-dynamic'
@@ -49,31 +53,24 @@ export async function POST(req: NextRequest) {
 
   const summariesString = formatDailySummaries(dailySummaries)
 
-  const response = await getOpenAI().chat.completions.create({
-    ...O3_CONFIG,
-    messages: [
-      { role: 'system', content: WEEKLY_SUMMARY_SYSTEM_PROMPT },
-      {
-        role: 'user',
-        content: getWeeklySummaryUserPrompt({
-          startDate: body.weekStartDate,
-          endDate: body.weekEndDate,
-          summaries: summariesString,
-        }),
-      },
-    ],
+  const aiContent = await generateAiText({
+    prompt: getWeeklySummaryUserPrompt({
+      startDate: body.weekStartDate,
+      endDate: body.weekEndDate,
+      summaries: summariesString,
+    }),
+    system: WEEKLY_SUMMARY_SYSTEM_PROMPT,
   })
 
-  if (!response.choices[0]?.message?.content) {
+  if (!aiContent) {
     return new Response('No content found in response', { status: 500 })
   }
-  
-  const aiContent = response.choices[0].message.content
+
   if (!validateMarkdownContent(aiContent)) {
     console.error('Invalid markdown content received from AI')
     return new Response('Invalid content in AI response', { status: 500 })
   }
-  
+
   const responseContent = `# Weekly Summary for ${body.weekStartDate} - ${body.weekEndDate}\n${aiContent.trim()}`
   const filename = `${process.env.WEEKLY_SUMMARY_NAME} ${dayjs().format('YYYY-MM-DD')}${process.env.NODE_ENV === 'development' ? `-DEV` : ''}.md`
 
@@ -94,7 +91,7 @@ export async function GET(req: NextRequest) {
   ) {
     return new Response('Unauthorized', { status: 401 })
   }
-  if (!process.env.YOUR_NAME || !process.env.OPENAI_API_KEY) {
+  if (!process.env.YOUR_NAME || !hasAiCredentials()) {
     // Treating this as if user does not want weekly summaries.
     return new Response('Missing environment variables', { status: 200 })
   }

--- a/env.example
+++ b/env.example
@@ -18,8 +18,9 @@ QSTASH_CURRENT_SIGNING_KEY=
 QSTASH_NEXT_SIGNING_KEY=
 
 # AI
+AI_GATEWAY_API_KEY=
+# Optional BYOK credential for AI Gateway provider routing.
 OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
 
 # Summaries
 TIMEZONE="America/New_York"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@anatine/zod-openapi": "^2.2.6",
-    "@anthropic-ai/sdk": "^0.91.1",
     "@upstash/qstash": "^2.10.1",
     "@upstash/redis": "^1.37.0",
+    "ai": "^6.0.168",
     "axios": "^1.15.2",
     "cheerio": "^1.2.0",
     "dayjs": "^1.11.20",
@@ -24,14 +23,13 @@
     "jsonwebtoken": "^9.0.3",
     "next": "16.2.4",
     "octokit": "^5.0.5",
-    "openai": "^6.34.0",
     "pako": "^2.1.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "socks-proxy-agent": "^10.0.0",
     "string-byte-length": "^3.0.0",
     "turndown": "^7.2.4",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,18 +12,15 @@ importers:
 
   .:
     dependencies:
-      '@anatine/zod-openapi':
-        specifier: ^2.2.6
-        version: 2.2.8(openapi3-ts@4.4.0)(zod@3.25.61)
-      '@anthropic-ai/sdk':
-        specifier: ^0.91.1
-        version: 0.91.1(zod@3.25.61)
       '@upstash/qstash':
         specifier: ^2.10.1
         version: 2.10.1
       '@upstash/redis':
         specifier: ^1.37.0
         version: 1.37.0
+      ai:
+        specifier: ^6.0.168
+        version: 6.0.168(zod@4.3.6)
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -44,13 +41,10 @@ importers:
         version: 9.0.3
       next:
         specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       octokit:
         specifier: ^5.0.5
         version: 5.0.5
-      openai:
-        specifier: ^6.34.0
-        version: 6.34.0(zod@3.25.61)
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -70,8 +64,8 @@ importers:
         specifier: ^7.2.4
         version: 7.2.4
       zod:
-        specifier: ^3.23.8
-        version: 3.25.61
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/jsonwebtoken':
         specifier: ^9.0.10
@@ -130,24 +124,25 @@ importers:
 
 packages:
 
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@anatine/zod-openapi@2.2.8':
-    resolution: {integrity: sha512-iyM8mB556KdiZ6a1GTZ67ACLnJakU1hrzzXoh7PLaReldAdMq88MlZn/Ir/U56/TBuQctBhh/4seo0b0B343uw==}
-    peerDependencies:
-      openapi3-ts: ^4.1.2
-      zod: ^3.20.0
-
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -203,10 +198,6 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -641,12 +632,19 @@ packages:
     resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
     engines: {node: '>= 20'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -839,6 +837,10 @@ packages:
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -856,6 +858,12 @@ packages:
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -1406,6 +1414,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -1820,12 +1832,11 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2062,21 +2073,6 @@ packages:
   octokit@5.0.5:
     resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
     engines: {node: '>= 20'}
-
-  openai@6.34.0:
-    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openapi3-ts@4.4.0:
-    resolution: {integrity: sha512-9asTNB9IkKEzWMcHmVZE7Ts3kC9G7AFHfs8i7caD8HbI76gEjdkId4z/AkP83xdZsH7PLAnnbl47qZkXuxpArw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2495,18 +2491,11 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-deepmerge@6.2.1:
-    resolution: {integrity: sha512-8CYSLazCyj0DJDpPIxOFzJG46r93uh6EynYjuey+bxcLltBeqZL7DMfaE5ZPzZNFlav7wx+2TDa/mBl8gkTYzw==}
-    engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -2654,11 +2643,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2672,21 +2656,30 @@ packages:
   zod@3.25.61:
     resolution: {integrity: sha512-fzfJgUw78LTNnHujj9re1Ov/JJQkRZZGDMcYqSx7Hp4rPOkKywaFHq0S6GoHeXs0wGNE/sIOutkXgnwzrVOGCQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
+  '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
   '@alloc/quick-lru@5.2.0': {}
-
-  '@anatine/zod-openapi@2.2.8(openapi3-ts@4.4.0)(zod@3.25.61)':
-    dependencies:
-      openapi3-ts: 4.4.0
-      ts-deepmerge: 6.2.1
-      zod: 3.25.61
-
-  '@anthropic-ai/sdk@0.91.1(zod@3.25.61)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.61
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2764,8 +2757,6 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -3212,10 +3203,14 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/webhooks-methods': 6.0.0
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3411,6 +3406,8 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vercel/oidc@3.2.0': {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3420,6 +3417,14 @@ snapshots:
   agent-base@7.1.4: {}
 
   agent-base@9.0.0: {}
+
+  ai@6.0.168(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
 
   ajv@6.15.0:
     dependencies:
@@ -4134,6 +4139,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventsource-parser@3.0.8: {}
+
   extend@3.0.2: {}
 
   fast-content-type-parse@3.0.0: {}
@@ -4577,12 +4584,9 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
-
   json-schema-traverse@0.4.1: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4725,7 +4729,7 @@ snapshots:
 
   neverthrow@7.2.0: {}
 
-  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -4744,6 +4748,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4824,14 +4829,6 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       '@octokit/webhooks': 14.2.0
-
-  openai@6.34.0(zod@3.25.61):
-    optionalDependencies:
-      zod: 3.25.61
-
-  openapi3-ts@4.4.0:
-    dependencies:
-      yaml: 2.8.3
 
   optionator@0.9.4:
     dependencies:
@@ -5331,13 +5328,9 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
-  ts-algebra@2.0.0: {}
-
   ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
-
-  ts-deepmerge@6.2.1: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -5533,8 +5526,6 @@ snapshots:
 
   yaml@2.8.0: {}
 
-  yaml@2.8.3: {}
-
   yocto-queue@0.1.0: {}
 
   zod-validation-error@4.0.2(zod@3.25.61):
@@ -5542,3 +5533,5 @@ snapshots:
       zod: 3.25.61
 
   zod@3.25.61: {}
+
+  zod@4.3.6: {}

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -1,36 +1,71 @@
-import { generateSchema } from '@anatine/zod-openapi'
-import Anthropic from '@anthropic-ai/sdk'
-import OpenAI from 'openai'
-import { z, ZodType } from 'zod'
+import { generateText, Output } from 'ai'
+import { z } from 'zod'
 
-let anthropic: Anthropic | null = null
-let openai: OpenAI | null = null
+export const GPT_5_5_MODEL = 'openai/gpt-5.5'
 
-export function getAnthropic() {
-  if (!anthropic) {
-    anthropic = new Anthropic({
-      apiKey: process.env.ANTHROPIC_API_KEY,
-    })
-  }
-
-  return anthropic
+function getGpt55ProviderOptions() {
+  return {
+    openai: {
+      reasoningEffort: 'high',
+    },
+    ...(process.env.OPENAI_API_KEY
+      ? {
+          gateway: {
+            byok: {
+              openai: [{ apiKey: process.env.OPENAI_API_KEY }],
+            },
+          },
+        }
+      : {}),
+  } as const
 }
 
-export function getOpenAI() {
-  if (!openai) {
-    openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-      organization: process.env.OPENAI_ORGANIZATION_ID,
-    })
-  }
-
-  return openai
+type GenerateAiTextOptions = {
+  prompt: string
+  system?: string
 }
 
-export const O3_CONFIG = {
-  model: 'o3',
-  reasoning_effort: 'high',
-} as const
+type GenerateAiObjectOptions<T extends z.ZodType> = GenerateAiTextOptions & {
+  schema: T
+}
+
+export function hasAiCredentials(): boolean {
+  return Boolean(
+    process.env.AI_GATEWAY_API_KEY ||
+      process.env.VERCEL_OIDC_TOKEN ||
+      process.env.VERCEL,
+  )
+}
+
+export async function generateAiText({
+  prompt,
+  system,
+}: GenerateAiTextOptions): Promise<string> {
+  const { text } = await generateText({
+    model: GPT_5_5_MODEL,
+    providerOptions: getGpt55ProviderOptions(),
+    prompt,
+    system,
+  })
+
+  return text
+}
+
+export async function generateAiObject<T extends z.ZodType>({
+  prompt,
+  schema,
+  system,
+}: GenerateAiObjectOptions<T>): Promise<z.infer<T>> {
+  const { output } = await generateText({
+    model: GPT_5_5_MODEL,
+    output: Output.object({ schema }),
+    providerOptions: getGpt55ProviderOptions(),
+    prompt,
+    system,
+  })
+
+  return schema.parse(output)
+}
 
 /**
  * Validates that a string contains valid markdown content
@@ -65,28 +100,14 @@ export function validateMarkdownContent(content: string): boolean {
   return true
 }
 
-export async function extractJson<T extends ZodType>(
+export async function extractJson<T extends z.ZodType>(
   string: string,
   zodType: T,
 ): Promise<z.infer<T>> {
-  const response = await getOpenAI().chat.completions.create({
-    ...O3_CONFIG,
-    messages: [
-      {
-        role: 'system',
-        content: `Please extract the JSON object from the user's text. Use the following OpenAPI schema: ${generateSchema(zodType)}`,
-      },
-      {
-        role: 'user',
-        content: string,
-      },
-    ],
+  return generateAiObject({
+    prompt: string,
+    schema: zodType,
+    system:
+      "Please extract the JSON object from the user's text. Return only data that matches the requested schema.",
   })
-
-  if (!response || !response.choices[0].message.content) {
-    throw new Error('No content found in response')
-  }
-
-  const parsedContent = JSON.parse(response.choices[0].message.content)
-  return zodType.parse(parsedContent)
 }

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { getOpenAI, O3_CONFIG } from './ai'
+import { generateAiObject } from './ai'
 import { getRedis } from './redis'
 import { scrapeUrl } from './scrape'
 
@@ -13,12 +13,8 @@ export async function processUrl(url: string, urlBodiesKey: string) {
   try {
     const body = await scrapeUrl(url) // Replace with your scraping function
     if (body?.body) {
-      const response = await getOpenAI().chat.completions.create({
-        ...O3_CONFIG,
-        messages: [
-          {
-            role: 'user',
-            content: `You are tasked with summarizing the content of a website based on its title and body. Your goal is to create a concise yet informative summary that captures the main points of the content.
+      const urlSummary = await generateAiObject({
+        prompt: `You are tasked with summarizing the content of a website based on its title and body. Your goal is to create a concise yet informative summary that captures the main points of the content.
 
 Here is the content to summarize:
 
@@ -42,17 +38,12 @@ Provide your response as a JSON object with the following structure:
 }
 
 Do not include any explanation or additional text outside of this JSON object.`,
-          },
-        ],
-        response_format: { type: 'json_object' },
+        schema: urlResponse,
       })
-      if (!response.choices[0]?.message?.content) {
+      if (!urlSummary) {
         console.error(`Failed to summarize URL: ${url}`)
         throw new Error('Failed to summarize URL')
       }
-      const urlSummary = urlResponse.parse(
-        JSON.parse(response.choices[0].message.content),
-      )
       if (!urlSummary.skipUrl) {
         const redis = getRedis()
         await redis.hset(urlBodiesKey, {


### PR DESCRIPTION
## Summary

- Migrate all AI generation paths to Vercel AI SDK v6 using AI Gateway model `openai/gpt-5.5`.
- Centralize text and structured object generation in `utils/ai.ts`.
- Remove direct OpenAI/Anthropic SDK usage and obsolete model references.
- Update environment example for AI Gateway auth and optional OpenAI BYOK routing.

## Validation

- `pnpm lint`
- `pnpm tsc`
- `pnpm build`
- `git diff --check`

## Notes

The earlier Qstash failure from `NEXT_PUBLIC_SITE_URL`/DNS remains separate from this migration.